### PR TITLE
install.deb: update cache when installing

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,7 +1,10 @@
 ---
 
 - name: Install requirements (Debian)
-  apt: name={{item}}
+  apt:
+    name: "{{item}}"
+    update_cache: yes
+    cache_valid_time: 3600
   with_items: [openvpn, udev, openssl]
 
 - name: Install apt extras


### PR DESCRIPTION
To allow updating the cache when it's old (like for an AMI) where the
cache contains package versions that are no longer stored in the repos